### PR TITLE
Fix Vivado Bind Mount Permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.bin
+installer/

--- a/docker.sh
+++ b/docker.sh
@@ -21,7 +21,7 @@ fi
 # Check if the Web Installer is present
 numberOfInstallers=0
 
-for f in /home/user/Xilinx*.bin; do
+for f in /home/user/*.bin; do
 	((numberOfInstallers++))
 done
 
@@ -38,19 +38,23 @@ cd /home/user
 
 VIVADO_VERSION=0
 # checking version
-if [[ $(md5sum -b /home/user/Xilinx*.bin) =~ "e47ad71388b27a6e2339ee82c3c8765f" ]]
+if [[ $(md5sum -b /home/user/*.bin) =~ "e47ad71388b27a6e2339ee82c3c8765f" ]]
 then
 	VIVADO_VERSION=2023
 else
 	VIVADO_VERSION=2022
 fi
 
-echo $VIVADO_VERSION
+f_echo "Vivado Version: $VIVADO_VERSION"
 
 # Extract installer
 f_echo "Extracting installer"
-chmod +x /home/user/Xilinx*.bin
-/home/user/Xilinx*.bin --target /home/user/installer --noexec
+mkdir /temp
+cp /home/user/*.bin /temp
+chmod +x /temp/*.bin
+/temp/*.bin --target /temp --noexec
+cp -r /temp /home/user/installer
+rm -rf /temp
 
 # Get AuthToken by repeating the following command until it succeeds
 f_echo "Log into your Xilinx account to download the necessary files."

--- a/install.sh
+++ b/install.sh
@@ -50,14 +50,19 @@ done
 f_echo "Building Docker image"
 docker build -t x64-linux .
 
-# Copy Vivado installation file into $script_dir
-installation_binary=""
-while ! [[ $installation_binary == *.bin ]]
-do
-	f_echo "Drag and drop the installation binary into this terminal window and press Enter: "
-	read installation_binary
-done
-cp $installation_binary $script_dir
+# Copy Vivado installation file into $script_dir if it is not already there
+found_installation_binary=$(find $script_dir -name "*.bin")
+if [ -z "$found_installation_binary" ]; then
+	installation_binary=""
+	while ! [[ $installation_binary == *.bin ]]
+	do
+		f_echo "Drag and drop the installation binary into this terminal window and press Enter: "
+		read installation_binary
+	done
+	cp $installation_binary $script_dir
+else
+	f_echo "Found installation binary"
+fi
 
 # Running install script in docker container
 f_echo "Launching Docker container and installation script"

--- a/install_config_2022.txt
+++ b/install_config_2022.txt
@@ -3,11 +3,11 @@ Edition=Vivado ML Standard
 
 Product=Vivado
 
-# Path where Xilinx software will be installed.
+# Path where AMD FPGAs & Adaptive SoCs software will be installed.
 Destination=/home/user/Xilinx
 
 # Choose the Products/Devices the you would like to install.
-Modules=Virtex UltraScale+ HBM:1,DocNav:1,Kintex UltraScale:1,Artix UltraScale+:1,Spartan-7:1,Artix-7:1,Virtex UltraScale+:1,Vitis Model Composer(Xilinx Toolbox for MATLAB and Simulink. Includes the functionality of System Generator for DSP):1,Zynq UltraScale+ MPSoC:1,Zynq-7000:1,Virtex UltraScale+ 58G:1,Kintex-7:1,Install Devices for Kria SOMs and Starter Kits:1,Kintex UltraScale+:1
+Modules=Virtex UltraScale+ HBM:1,Kintex UltraScale:1,Vitis Networking P4:0,Artix UltraScale+:1,Spartan-7:1,Artix-7:1,Virtex UltraScale+:1,Vitis Model Composer(Toolbox for MATLAB and Simulink. Includes the functionality of System Generator for DSP):1,DocNav:1,Zynq UltraScale+ MPSoC:1,Zynq-7000:1,Virtex UltraScale+ 58G:1,Vitis Embedded Development:0,Kintex-7:1,Install Devices for Kria SOMs and Starter Kits:1,Kintex UltraScale+:1
 
 # Choose the post install scripts you'd like to run as part of the finalization step. Please note that some of these scripts may require user interaction during runtime.
 InstallOptions=
@@ -20,7 +20,7 @@ CreateProgramGroupShortcuts=1
 ProgramGroupFolder=Xilinx Design Tools
 
 # Choose whether shortcuts will be created for All users or just the Current user. Shortcuts can be created for all users only if you run the installer as administrator.
-CreateShortcutsForAllUsers=1
+CreateShortcutsForAllUsers=0
 
 # Choose whether shortcuts will be created on the desktop or not.
 CreateDesktopShortcuts=1


### PR DESCRIPTION
This fixes the issues discussed here: https://github.com/ichi4096/vivado-on-silicon-mac/issues/29
Also fixes: https://github.com/ichi4096/vivado-on-silicon-mac/issues/27

List of changes:
* Ignore `*.bin` and the `installer/` folder
* Change occurrences of `Xilinx*.bin` to `*.bin` to account for installer name changes
* Extracts installer in `/temp`, then moves extracted files to mounted `/installer` to have correct permissions
* If the `/installer` folder already exists, don't prompt for new installer bin
* Update Vivado 2022 installer .txt file