### PR TITLE
Fixed the frontend errors and solution path for ca-certificate error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ You first need to install [Docker®](https://www.docker.com/products/docker-desk
 
 You will also need the Vivado installer file (the "Linux® Self Extracting Web Installer").
 
+You may have to reinstall the Rosetta 2 on your Mac, because [it may fail to build due to the illegal compiler instructions](https://github.com/docker/for-mac/issues/7255). To *possibly* fix this use the following in the terminal:
+```
+softwareupdate --install-rosetta --agree-to-license
+```
+
 ### Installation
 1. Download this [tool](https://github.com/ichi4096/vivado-on-silicon-mac/archive/refs/heads/main.zip).
 2. Extract the ZIP file.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,10 @@ Expect the installation process to last about one to two hours and download ~20 
 ### Preparations
 You first need to install [Docker®](https://www.docker.com/products/docker-desktop/) (make sure to choose "Apple Chip" instead of "Intel Chip"). You may find it useful to disable the option "Open Docker Dashboard when Docker Desktop starts".
 
+Rossetta must be installed on your Mac. The installer will ask you to install it if it is not already installed.
+
 You will also need the Vivado installer file (the "Linux® Self Extracting Web Installer").
 
-You may have to reinstall the Rosetta 2 on your Mac, because [it may fail to build due to the illegal compiler instructions](https://github.com/docker/for-mac/issues/7255). To *possibly* fix this use the following in the terminal:
-```
-softwareupdate --install-rosetta --agree-to-license
-```
 
 ### Installation
 1. Download this [tool](https://github.com/ichi4096/vivado-on-silicon-mac/archive/refs/heads/main.zip).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vivado-on-silicon-mac
-This is a tool for installing [Vivado™](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools.html) on Arm®-based Apple silicon Macs in a Rosett-enabled virtual machine. It is in no way associated with Xilinx or AMD.
+This is a tool for installing [Vivado™](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools.html) on Arm®-based Apple Silicon Macs in a Rosetta-enabled virtual machine. It is in no way associated with Xilinx or AMD.
 
 *Updated for 2024!*
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,10 @@ FROM --platform=linux/amd64 ubuntu:22.04
 RUN apt update && apt upgrade -y
 
 # Fix the error of build failing due to not having the frontend installed
-RUN apt-get install dialog apt-utils -y
+# This enviroment auto fallbacks to noninteractive mode, with the declaration following this guidance:
+# https://bobcares.com/blog/debian_frontendnoninteractive-docker/
+# https://github.com/moby/moby/issues/4032#issuecomment-34597177
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Check and install ca-certificates earlier if Rosetta gets broken
 RUN apt -y install ca-certificates

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -3,11 +3,17 @@
 FROM --platform=linux/amd64 ubuntu:22.04
 RUN apt update && apt upgrade -y
 
+# Fix the error of build failing due to not having the frontend installed
+RUN apt-get install dialog apt-utils -y
+
+# Check and install ca-certificates earlier if Rosetta gets broken
+RUN apt -y install ca-certificates
+
 # install gui
 RUN apt install -y --no-install-recommends --allow-unauthenticated \
 dbus dbus-x11 x11-utils xorg alsa-utils mesa-utils net-tools \
 libgl1-mesa-dri gtk2-engines lxappearance fonts-droid-fallback sudo firefox \
-ubuntu-gnome-default-settings ca-certificates curl gnupg lxde arc-theme \
+ubuntu-gnome-default-settings curl gnupg lxde arc-theme \
 gtk2-engines-murrine gtk2-engines-pixbuf gnome-themes-standard nano xterm
 
 # install dependencies for Vivado

--- a/scripts/gen_image.sh
+++ b/scripts/gen_image.sh
@@ -13,6 +13,8 @@ f_echo "Building Docker image..."
 if ! docker build -t x64-linux "$script_dir"
 then
 	f_echo "Docker image generation failed!"
+	f_echo "If the error has been encountered at ca-certificates, please run the following command:"
+	f_echo "softwareupdate --install-rosetta --agree-to-license"
 	exit 1
 fi
 

--- a/scripts/gen_image.sh
+++ b/scripts/gen_image.sh
@@ -13,8 +13,6 @@ f_echo "Building Docker image..."
 if ! docker build -t x64-linux "$script_dir"
 then
 	f_echo "Docker image generation failed!"
-	f_echo "If the error has been encountered at ca-certificates, please run the following command:"
-	f_echo "softwareupdate --install-rosetta --agree-to-license"
 	exit 1
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,39 @@ source "$script_dir/header.sh"
 # Make sure that the script is run in macOS and not the Docker container
 validate_macos
 
+# Check if Rosetta is installed
+if /usr/bin/pgrep -q oahd || /usr/bin/pgrep -q oahd-bin
+then
+  f_echo "Rosetta is installed! If there's illegal instruction compile error, try reinstall!"
+else
+  f_echo "Rosetta is not installed!"
+  # Check the consent of the user
+  f_echo "Do you want to install Rosetta?"
+  f_echo "1. Yes"
+  f_echo "2. No"
+  read rosetta_install
+  case $rosetta_install in
+    1)
+      f_echo "Installing Rosetta..."
+      if ! softwareupdate --install-rosetta
+      then
+        f_echo "Error installing Rosetta."
+        exit 1
+      fi
+      f_echo "Rosetta was successfully installed."
+      ;;
+    2)
+      f_echo "Rosetta is required to run the Docker container."
+      f_echo "Please install Rosetta and run this script again."
+      exit 1
+      ;;
+    *)
+      f_echo "Invalid option."
+      exit 1
+      ;;
+  esac
+fi
+
 # Make sure there are no previous installations in this folder
 if [ -d "$script_dir/../Xilinx" ]
 then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,23 +12,21 @@ if /usr/bin/pgrep -q oahd || /usr/bin/pgrep -q oahd-bin
 then
   f_echo "Rosetta is installed! If there's illegal instruction compile error, try reinstall!"
 else
-  f_echo "Rosetta is not installed!"
+  f_echo "Rosetta is not installed (required)!"
   # Check the consent of the user
-  f_echo "Do you want to install Rosetta?"
-  f_echo "1. Yes"
-  f_echo "2. No"
+  f_echo "Do you want to install Rosetta? Agreeing assumes that you also agree with its license. (Y/n)"
   read rosetta_install
   case $rosetta_install in
-    1)
+    [yY]|[yY][eE]*)
       f_echo "Installing Rosetta..."
-      if ! softwareupdate --install-rosetta
+      if ! softwareupdate --install-rosetta --agree-to-license
       then
         f_echo "Error installing Rosetta."
         exit 1
       fi
       f_echo "Rosetta was successfully installed."
       ;;
-    2)
+    [nN]|[nN][oO]*)
       f_echo "Rosetta is required to run the Docker container."
       f_echo "Please install Rosetta and run this script again."
       exit 1


### PR DESCRIPTION
Added proposed guidance in the image generation and README if one cannot install the image using the Rosetta 2 in case of ca-certificate throwing illegal instruction error.

Also resolved the missing library for the frontend, per [this](https://github.com/moby/moby/issues/27988)

```
...
115.2 Processing triggers for ca-certificates (20230311 ubuntu0.22.04.1)...
115.2 Updating certificates in /etc/ssl/certs...
116.6 Illegal instruction
...
121.8 Errors were encountered while processing:
121.8  ca-certificates
121.8 E: Sub-process /usr/bin/dpkg returned an error code (1)
------

 2 warnings found (use docker --debug to expand):
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 3)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 53)
Dockerfile:10
--------------------
   9 |     # install gui
  10 | >>> RUN apt install -y --no-install-recommends --allow-unauthenticated \
  11 | >>> dbus dbus-x11 x11-utils xorg alsa-utils mesa-utils net-tools \
  12 | >>> libgl1-mesa-dri gtk2-engines lxappearance fonts-droid-fallback sudo firefox \
  13 | >>> ubuntu-gnome-default-settings curl gnupg lxde arc-theme \
  14 | >>> gtk2-engines-murrine gtk2-engines-pixbuf gnome-themes-standard nano xterm
  15 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt install -y --no-install-recommends --allow-unauthenticated dbus dbus-x11 x11-utils xorg alsa-utils mesa-utils net-tools libgl1-mesa-dri gtk2-engines lxappearance fonts-droid-fallback sudo firefox ubuntu-gnome-default-settings curl gnupg lxde arc-theme gtk2-engines-murrine gtk2-engines-pixbuf gnome-themes-standard nano xterm" did not complete successfully: exit code: 100

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/ae9xosgwnd9q8s6ox0ywssjh4
Docker image generation failed!
```