### PR TITLE
Add support for Vivado 2021.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 .DS_Store
 *.bin
+*Xilinx/
+.cache/
+.config/
+.java/
+.local/
+Desktop/
+installer/
+.XIC.lock
+.Xauthority
+.dbus/
+.vnc/
+.xsession-errors

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ The repository's contents are licensed under the Creative Commons Zero v1.0 Univ
 
 Note that the scripts are configured such that you automatically agree to Xilinx' and 3rd party EULAs (which can be obtained by extracting the installer yourself) by running them. You also automatically agree to [Apple's software licence agreement](https://www.apple.com/legal/sla/) for Rosetta 2.
 
+If you are installing Vivado version 2021.1:
+- WebTalk data collection is enabled, and you automatically agree to the corresponding terms.
+- For more information, see: https://docs.amd.com/r/2021.1-English/ug973-vivado-release-notes-install-license/WebTalk-Participation.
+
 This repository contains the modified source code of [xvcd](https://github.com/tmbinc/xvcd) as well as a compiled version which is statically linked against [libusb](https://libusb.info/) and [libftdi](https://www.intra2net.com/en/developer/libftdi/). This is in accordance to the [LGPL Version 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html), under which both of those libraries are licensed.
 
 Vivado and Xilinx are trademarks of Xilinx, Inc.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a tool for installing [Vivado™](https://www.xilinx.com/support/downloa
 *Updated for 2024!*
 
 The supported versions are:
+- 2021.1
 - 2022.2
 - 2023.1
 - 2023.2

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,24 +1,24 @@
 # Container for running Vivado on M1/M2 macs
 # though it should work equally on Intel macs
 FROM --platform=linux/amd64 ubuntu:22.04
-RUN apt update && apt upgrade -y
+RUN apt-get update && apt-get upgrade -y
 
 # install gui
-RUN apt install -y --no-install-recommends --allow-unauthenticated \
-dbus dbus-x11 x11-utils xorg alsa-utils mesa-utils net-tools \
-libgl1-mesa-dri gtk2-engines lxappearance fonts-droid-fallback sudo firefox \
-ubuntu-gnome-default-settings ca-certificates curl gnupg lxde arc-theme \
-gtk2-engines-murrine gtk2-engines-pixbuf gnome-themes-standard nano xterm
+RUN apt-get install -y --no-install-recommends --allow-unauthenticated \
+    dbus dbus-x11 x11-utils xorg alsa-utils mesa-utils net-tools \
+    libgl1-mesa-dri gtk2-engines lxappearance fonts-droid-fallback sudo firefox \
+    ubuntu-gnome-default-settings ca-certificates curl gnupg lxde arc-theme \
+    gtk2-engines-murrine gtk2-engines-pixbuf gnome-themes-standard nano xterm
 
 # install dependencies for Vivado
-RUN apt install -y --no-install-recommends --allow-unauthenticated \
-python3-pip python3-dev build-essential git gcc-multilib g++ \
-ocl-icd-opencl-dev libjpeg62-dev libc6-dev-i386 graphviz make \
-unzip libtinfo5 xvfb libncursesw5 locales libswt-gtk-4-jni
+RUN apt-get install -y --no-install-recommends --allow-unauthenticated \
+    python3-pip python3-dev build-essential git gcc-multilib g++ \
+    ocl-icd-opencl-dev libjpeg62-dev libc6-dev-i386 graphviz make \
+    unzip libtinfo5 xvfb libncursesw5 locales libswt-gtk-4-jni
 
 # install vnc server (with recommended installs)
-RUN apt install -y --allow-unauthenticated \
-tigervnc-standalone-server tigervnc-xorg-extension
+RUN apt-get install -y --allow-unauthenticated \
+    tigervnc-standalone-server tigervnc-xorg-extension
 
 # create user "user" with password "password"
 RUN useradd --create-home --shell /bin/bash --user-group --groups adm,sudo user
@@ -28,7 +28,7 @@ RUN chown -R user:user /home/user
 # setup LXDE
 RUN mkdir -p /home/user/.config/pcmanfm/LXDE/
 RUN ln -sf /usr/local/share/doro-lxde-wallpapers/desktop-items-0.conf \
-/home/user/.config/pcmanfm/LXDE/
+    /home/user/.config/pcmanfm/LXDE/
 RUN mv /usr/bin/lxpolkit /usr/bin/lxpolkit.bak
 #RUN echo "" >> /etc/xdg/lxsession/LXDE/autostart
 #RUN echo "@lxterminal -e /home/user/scripts/de_start.sh" >> /etc/xdg/lxsession/LXDE/autostart

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,20 +4,20 @@ FROM --platform=linux/amd64 ubuntu:22.04
 RUN apt-get update && apt-get upgrade -y
 
 # install gui
-RUN apt-get install -y --no-install-recommends --allow-unauthenticated \
+RUN apt-get install -y --no-install-recommends \
     dbus dbus-x11 x11-utils xorg alsa-utils mesa-utils net-tools \
     libgl1-mesa-dri gtk2-engines lxappearance fonts-droid-fallback sudo firefox \
     ubuntu-gnome-default-settings ca-certificates curl gnupg lxde arc-theme \
     gtk2-engines-murrine gtk2-engines-pixbuf gnome-themes-standard nano xterm
 
 # install dependencies for Vivado
-RUN apt-get install -y --no-install-recommends --allow-unauthenticated \
+RUN apt-get install -y --no-install-recommends \
     python3-pip python3-dev build-essential git gcc-multilib g++ \
     ocl-icd-opencl-dev libjpeg62-dev libc6-dev-i386 graphviz make \
     unzip libtinfo5 xvfb libncursesw5 locales libswt-gtk-4-jni
 
 # install vnc server (with recommended installs)
-RUN apt-get install -y --allow-unauthenticated \
+RUN apt-get install -y \
     tigervnc-standalone-server tigervnc-xorg-extension
 
 # create user "user" with password "password"

--- a/scripts/hashes.sh
+++ b/scripts/hashes.sh
@@ -9,6 +9,7 @@
 
 # hashes for the web installer
 declare -A web_hashes=(
+    ["a6b118fffbcfdc7376c2640f276e2ca9"]=202110
     ["9bf473b6be0b8531e70fd3d5c0fe4817"]=202220
     ["e47ad71388b27a6e2339ee82c3c8765f"]=202310
     ["b8c785d03b754766538d6cde1277c4f0"]=202320

--- a/scripts/install_configs/202110.txt
+++ b/scripts/install_configs/202110.txt
@@ -1,0 +1,33 @@
+#### Vivado ML Standard Install Configuration ####
+Edition=Vivado ML Standard
+
+Product=Vivado
+
+# Path where Xilinx software will be installed.
+Destination=/home/user/Xilinx
+
+# Choose the Products/Devices the you would like to install.
+Modules=Virtex UltraScale+ HBM:1,Zynq UltraScale+ MPSoC:1,DocNav:1,Kintex UltraScale:1,Zynq-7000:1,Spartan-7:1,Artix-7:1,Virtex UltraScale+:1,Kintex-7:1,Kintex UltraScale+:1,Vitis Model Composer(Xilinx Toolbox for MATLAB and Simulink. Includes the functionality of System Generator for DSP):1
+
+# Choose the post install scripts you'd like to run as part of the finalization step. Please note that some of these scripts may require user interaction during runtime.
+InstallOptions=
+
+## Shortcuts and File associations ##
+# Choose whether Start menu/Application menu shortcuts will be created or not.
+CreateProgramGroupShortcuts=1
+
+# Choose the name of the Start menu/Application menu shortcut. This setting will be ignored if you choose NOT to create shortcuts.
+ProgramGroupFolder=Xilinx Design Tools
+
+# Choose whether shortcuts will be created for All users or just the Current user. Shortcuts can be created for all users only if you run the installer as administrator.
+CreateShortcutsForAllUsers=0
+
+# Choose whether shortcuts will be created on the desktop or not.
+CreateDesktopShortcuts=1
+
+# Choose whether file associations will be created or not.
+CreateFileAssociation=1
+
+# Choose whether disk usage will be optimized (reduced) after installation
+EnableDiskUsageOptimization=1
+

--- a/scripts/install_vivado.sh
+++ b/scripts/install_vivado.sh
@@ -27,7 +27,14 @@ done
 # Run installer
 f_echo "You successfully logged into your account. The installation will begin now."
 eula_args="XilinxEULA,3rdPartyEULA"
-[ "$vivado_version" = "202110" ] && eula_args="${eula_args},WebTalkTerms"
+
+# Check if the version is 202110 to include WebTalk terms
+if [ "$vivado_version" = "202110" ]; then
+    eula_args="${eula_args},WebTalkTerms"
+    f_echo "Note: The 2021.1 version enables WebTalk data collection and agrees automatically to the corresponding terms."
+    f_echo "For more information, see: https://docs.amd.com/r/2021.1-English/ug973-vivado-release-notes-install-license/WebTalk-Participation"
+    wait_for_user_input
+fi
 
 if /home/user/installer/xsetup -c "/home/user/scripts/install_configs/${vivado_version}.txt" -b Install -a "${eula_args}"
 then

--- a/scripts/install_vivado.sh
+++ b/scripts/install_vivado.sh
@@ -26,11 +26,14 @@ done
 
 # Run installer
 f_echo "You successfully logged into your account. The installation will begin now."
-if /home/user/installer/xsetup -c "/home/user/scripts/install_configs/$vivado_version.txt" -b Install -a XilinxEULA,3rdPartyEULA
+eula_args="XilinxEULA,3rdPartyEULA"
+[ "$vivado_version" = "202110" ] && eula_args="${eula_args},WebTalkTerms"
+
+if /home/user/installer/xsetup -c "/home/user/scripts/install_configs/${vivado_version}.txt" -b Install -a "${eula_args}"
 then
     f_echo "Vivado was successfully installed."
     f_echo "Run start_container.sh to launch it."
 else
-    f_echo "An error occured during installation. Please run cleanup.sh and try again."
-    exit1
+    f_echo "An error occurred during installation. Please run cleanup.sh and try again."
+    exit 1
 fi


### PR DESCRIPTION
Adds support for installing Vivado 2021.1 as that's the version my course is currently using.

Note the latest officially supported version of ubuntu is 20.04, however at the moment, I'm not seeing any issues using 22.04.

I was looking at updating the scripts to modify the Docker image that's built using command line args, so I'm just putting this draft at the moment to get any initial feedback.