### PR TITLE
Fix Docker Image Not Found and Other Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *Xilinx/
 .cache/
 .config/
+.fontconfig/
 .java/
 .local/
 Desktop/

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -56,4 +56,4 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 # Without this, Vivado will crash when synthesizing
-ENV LD_PRELOAD /lib/x86_64-linux-gnu/libudev.so.1 /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0
+ENV LD_PRELOAD="/lib/x86_64-linux-gnu/libudev.so.1 /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0"

--- a/scripts/gen_image.sh
+++ b/scripts/gen_image.sh
@@ -10,7 +10,7 @@ start_docker
 
 # Build the Docker image according to the Dockerfile
 f_echo "Building Docker image..."
-if ! docker build -t x64-linux "$script_dir"
+if ! docker build --platform linux/amd64 -t x64-linux "$script_dir"
 then
 	f_echo "Docker image generation failed!"
 	exit 1


### PR DESCRIPTION
My Mac (m2 macbook air) would always complain about the image not being found: `Unable to find image 'x64-linux:latest' locally
docker: Error response from daemon: pull access denied for x64-linux, repository does not exist or may require 'docker login'.` Despite it showing up in `docker image ls`. The fix was simple, found here: https://github.com/docker/cli/issues/3286#issuecomment-1168394369. Just set the platform at build.

This warning would come up when buidling the Docker image: `- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 59)`. This was fixed by setting the env value using the = like the keys a few lines above.

Adds the `.fontconfig/` folder to the git ignore.