### PR TITLE
Add support for Vivado 2024.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vivado-on-silicon-mac
 This is a tool for installing [Vivado™](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools.html) on Arm®-based Apple Silicon Macs in a Rosetta-enabled virtual machine. It is in no way associated with Xilinx or AMD.
 
-*Updated for 2024!*
+*Updated for November 2024!*
 
 The supported versions are:
 - 2021.1
@@ -9,6 +9,7 @@ The supported versions are:
 - 2023.1
 - 2023.2
 - 2024.1
+- 2024.2
 
 Due to unexpected behaviour in Rosetta emulation, most versions of macOS 14 (including 14.5) are not supported. macOS 13 may work, but the above versions were tested on macOS 15.
 

--- a/scripts/hashes.sh
+++ b/scripts/hashes.sh
@@ -14,6 +14,7 @@ declare -A web_hashes=(
     ["e47ad71388b27a6e2339ee82c3c8765f"]=202310
     ["b8c785d03b754766538d6cde1277c4f0"]=202320
     ["8b0e99a41b851b50592d5d6ef1b1263d"]=202410
+    ["20c806793b3ea8d79273d5138fbd195f"]=202420
 )
 # hashes for the full installer
 # not tested yet

--- a/scripts/install_configs/202420.txt
+++ b/scripts/install_configs/202420.txt
@@ -1,0 +1,32 @@
+#### Vivado ML Standard Install Configuration ####
+Edition=Vivado ML Standard
+
+Product=Vivado
+
+# Path where AMD FPGAs & Adaptive SoCs software will be installed.
+Destination=/home/user/Xilinx
+
+# Choose the Products/Devices the you would like to install.
+Modules=Virtex UltraScale+ HBM:1,Kintex UltraScale:1,Vitis Networking P4:0,Artix UltraScale+:1,Spartan-7:1,Artix-7:1,Virtex UltraScale+:1,Vitis Model Composer(Toolbox for MATLAB and Simulink. Includes the functionality of System Generator for DSP):1,DocNav:1,Zynq UltraScale+ MPSoC:1,Zynq-7000:1,Virtex UltraScale+ 58G:1,Power Design Manager (PDM):0,Vitis Embedded Development:0,Kintex-7:1,Install Devices for Kria SOMs and Starter Kits:1,Kintex UltraScale+:1
+
+# Choose the post install scripts you'd like to run as part of the finalization step. Please note that some of these scripts may require user interaction during runtime.
+InstallOptions=
+
+## Shortcuts and File associations ##
+# Choose whether Start menu/Application menu shortcuts will be created or not.
+CreateProgramGroupShortcuts=1
+
+# Choose the name of the Start menu/Application menu shortcut. This setting will be ignored if you choose NOT to create shortcuts.
+ProgramGroupFolder=Xilinx Design Tools
+
+# Choose whether shortcuts will be created for All users or just the Current user. Shortcuts can be created for all users only if you run the installer as administrator.
+CreateShortcutsForAllUsers=0
+
+# Choose whether shortcuts will be created on the desktop or not.
+CreateDesktopShortcuts=1
+
+# Choose whether file associations will be created or not.
+CreateFileAssociation=1
+
+# Choose whether disk usage will be optimized (reduced) after installation
+EnableDiskUsageOptimization=1


### PR DESCRIPTION
Simply added support for the new 2024.2 release.
It builds and installs on my MacOS 15.1.1 M4.

Additionally I've got it to install and run Vitis by installing the dependencies mentioned in #37 in [sapertuz's comment](https://github.com/ichi4096/vivado-on-silicon-mac/issues/37#issuecomment-2411580909) + the `file` utility. Simply add these lines to the Dockerfile (**this is not included in this PR!** Just as an FYI if you want to add Vitis support)
```Dockerfile
# install dependencies for Vitis
RUN apt-get install -y --no-install-recommends \
    file libnss3 libasound2 libsecret-1-0
```

<img width="653" alt="Vivado and Vitis 2024.2 Screenshot" src="https://github.com/user-attachments/assets/ca95d4a1-227b-48e8-91c4-55028bfa696e">
