### PR TITLE
Added support for SFD installer and Docker 4.35+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ Due to unexpected behaviour in Rosetta emulation, most versions of macOS 14 (inc
 
 ## How to install
 Expect the installation process to last about one to two hours and download ~20 GB for the web installer.
+About 30 minutes for the local installer (SFD).
 
 ### Preparations
 You first need to install [Docker®](https://www.docker.com/products/docker-desktop/) (make sure to choose "Apple Chip" instead of "Intel Chip"). You may find it useful to disable the option "Open Docker Dashboard when Docker Desktop starts".
 
 Rosetta must be installed on your Mac. The installer will ask you to install it if it is not already installed.
 
-You will also need the Vivado installer file (the "Linux® Self Extracting Web Installer").
+You will also need the Vivado installer file (the "Linux® Self Extracting Web Installer" or the "SFD").
 
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vivado-on-silicon-mac
 This is a tool for installing [Vivado™](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools.html) on Arm®-based Apple Silicon Macs in a Rosetta-enabled virtual machine. It is in no way associated with Xilinx or AMD.
 
-*Updated for 2024!*
+*Updated for November 2024!*
 
 The supported versions are:
 - 2021.1
@@ -9,6 +9,7 @@ The supported versions are:
 - 2023.1
 - 2023.2
 - 2024.1
+- 2024.2
 
 Due to unexpected behaviour in Rosetta emulation, most versions of macOS 14 (including 14.5) are not supported. macOS 13 may work, but the above versions were tested on macOS 15.
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -10,7 +10,7 @@ cd $script_dir/..
 to_remove=(".cache" ".dbus" ".local" ".vnc" "Xilinx" ".Xilinx"
 "Desktop" "installer" ".bash_history" ".lesshst" ".sudo_as_admin_successful"
 ".Xauthority" ".xsession-errors" ".XIC.lock" ".mozilla" ".java" ".config"
-".fontconfig" )
+".fontconfig")
 for file in ${to_remove[@]}
 do
     rm -rf $file

--- a/scripts/configure_docker.sh
+++ b/scripts/configure_docker.sh
@@ -9,26 +9,30 @@ validate_macos
 function cannot_setup_docker {
     f_echo "Unfortunately, the script could not configure Docker automatically."
     f_echo "This means that you have to change the settings in the Docker Dashboard yourself:"
-    f_echo "Enable the Virtualization Framework, Rosetta emulation and set Swap to at least 2 GiB."
+    f_echo "Enable the Virtualization Framework, Rosetta emulation and set Swap to at least 4 GiB."
     f_echo "Restart Docker after applying the changes and then continue with the installation."
     wait_for_user_input
     exit 1
 }
 
-docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings.json"
-
-stop_docker
-
-# check if the settings file is in the expected place
-if ! [ -f "$docker_settings_file" ]
+# check for settings file
+if [ -f "$HOME/Library/Group Containers/group.com.docker/settings-store.json" ]
 then
+    docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings-store.json"
+elif [ -f "$HOME/Library/Group Containers/group.com.docker/settings.json" ]
+then
+    docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings.json"
+else
+    f_echo "Settings file not found."
     cannot_setup_docker
 fi
 
+stop_docker
+
 # check if the attributes to be modified exist
-if grep "\"useVirtualizationFramework\":" "$docker_settings_file" > /dev/null \
-&& grep "\"useVirtualizationFrameworkRosetta\":" "$docker_settings_file" > /dev/null \
-&& grep "\"swapMiB\":" "$docker_settings_file" > /dev/null
+if grep -i "\"UseVirtualizationFramework\":" "$docker_settings_file" > /dev/null \
+&& grep -i "\"UseVirtualizationFrameworkRosetta\":" "$docker_settings_file" > /dev/null \
+&& grep -i "\"SwapMiB\":" "$docker_settings_file" > /dev/null
 then
     :
 else
@@ -36,17 +40,17 @@ else
 fi
 
 # enable Virtualization Framework
-sed -i "" "s/\"useVirtualizationFramework\": false/\"useVirtualizationFramework\": true/" "$docker_settings_file"
+sed -i "" "s/\"UseVirtualizationFramework\": false/\"UseVirtualizationFramework\": true/" "$docker_settings_file"
 
 # enable Rosetta emulation
-sed -i "" "s/\"useVirtualizationFrameworkRosetta\": false/\"useVirtualizationFrameworkRosetta\": true/" "$docker_settings_file"
+sed -i "" "s/\"UseVirtualizationFrameworkRosetta\": false/\"UseVirtualizationFrameworkRosetta\": true/" "$docker_settings_file"
 
 # set swap to minimum 4 GiB
 minSwap=4096
-swapMiB=$(cat "$docker_settings_file" | grep "\"swapMiB\"" | sed "s/[^0-9]//g")
+swapMiB=$(cat "$docker_settings_file" | grep -i "\"SwapMiB\"" | sed "s/[^0-9]//g")
 if [ "$swapMiB" -lt "$minSwap" ]
 then
-    sed -i "" "s/\"swapMiB\": [0-9]*/\"swapMiB\": $minSwap/" "$docker_settings_file"
+    sed -i "" "s/\"SwapMiB\": [0-9]*/\"SwapMiB\": $minSwap/" "$docker_settings_file"
 fi
 
 f_echo "Configured Docker successfully"

--- a/scripts/configure_docker.sh
+++ b/scripts/configure_docker.sh
@@ -15,6 +15,8 @@ function cannot_setup_docker {
     exit 1
 }
 
+stop_docker
+
 # check for settings file
 if [ -f "$HOME/Library/Group Containers/group.com.docker/settings-store.json" ]
 then
@@ -26,8 +28,6 @@ else
     f_echo "Settings file not found."
     cannot_setup_docker
 fi
-
-stop_docker
 
 # check if the attributes to be modified exist
 if grep -i "\"UseVirtualizationFramework\":" "$docker_settings_file" > /dev/null \

--- a/scripts/hashes.sh
+++ b/scripts/hashes.sh
@@ -18,11 +18,12 @@ declare -A web_hashes=(
 )
 # hashes for the full installer
 # not tested yet
-declare -A sfd_hashes=()
-#declare -A sfd_hashes=(
-#    ["0bf810cf5eaa28a849ab52b9bfdd20a5"]=202210
-#    ["4b4e84306eb631fe67d3efb469122671"]=202220
-#    ["f2011ceba52b109e3551c1d3189a8c9c"]=202310
-#    ["64d64e9b937b6fd5e98b41811c74aab2"]=202320
-#    ["372c0b184e32001137424e395823de3c"]=202410
-#)
+# declare -A sfd_hashes=()
+declare -A sfd_hashes=(
+   ["0bf810cf5eaa28a849ab52b9bfdd20a5"]=202210
+   ["4b4e84306eb631fe67d3efb469122671"]=202220
+   ["f2011ceba52b109e3551c1d3189a8c9c"]=202310
+   ["64d64e9b937b6fd5e98b41811c74aab2"]=202320
+   ["372c0b184e32001137424e395823de3c"]=202410
+   ["0ca31a787bbdff82b55213522e604446"]=202420
+)

--- a/scripts/hashes.sh
+++ b/scripts/hashes.sh
@@ -14,6 +14,7 @@ declare -A web_hashes=(
     ["e47ad71388b27a6e2339ee82c3c8765f"]=202310
     ["b8c785d03b754766538d6cde1277c4f0"]=202320
     ["8b0e99a41b851b50592d5d6ef1b1263d"]=202410
+    ["20c806793b3ea8d79273d5138fbd195f"]=202420
 )
 # hashes for the full installer
 # not tested yet

--- a/scripts/install_configs/202420.txt
+++ b/scripts/install_configs/202420.txt
@@ -1,0 +1,32 @@
+#### Vivado ML Standard Install Configuration ####
+Edition=Vivado ML Standard
+
+Product=Vivado
+
+# Path where AMD FPGAs & Adaptive SoCs software will be installed.
+Destination=/home/user/Xilinx
+
+# Choose the Products/Devices the you would like to install.
+Modules=Virtex UltraScale+ HBM:1,Kintex UltraScale:1,Vitis Networking P4:0,Artix UltraScale+:1,Spartan-7:1,Artix-7:1,Virtex UltraScale+:1,Vitis Model Composer(Toolbox for MATLAB and Simulink. Includes the functionality of System Generator for DSP):1,DocNav:1,Zynq UltraScale+ MPSoC:1,Zynq-7000:1,Virtex UltraScale+ 58G:1,Power Design Manager (PDM):0,Vitis Embedded Development:0,Kintex-7:1,Install Devices for Kria SOMs and Starter Kits:1,Kintex UltraScale+:1
+
+# Choose the post install scripts you'd like to run as part of the finalization step. Please note that some of these scripts may require user interaction during runtime.
+InstallOptions=
+
+## Shortcuts and File associations ##
+# Choose whether Start menu/Application menu shortcuts will be created or not.
+CreateProgramGroupShortcuts=1
+
+# Choose the name of the Start menu/Application menu shortcut. This setting will be ignored if you choose NOT to create shortcuts.
+ProgramGroupFolder=Xilinx Design Tools
+
+# Choose whether shortcuts will be created for All users or just the Current user. Shortcuts can be created for all users only if you run the installer as administrator.
+CreateShortcutsForAllUsers=0
+
+# Choose whether shortcuts will be created on the desktop or not.
+CreateDesktopShortcuts=1
+
+# Choose whether file associations will be created or not.
+CreateFileAssociation=1
+
+# Choose whether disk usage will be optimized (reduced) after installation
+EnableDiskUsageOptimization=1

--- a/scripts/install_vivado.sh
+++ b/scripts/install_vivado.sh
@@ -6,23 +6,33 @@ script_dir=$(dirname -- "$(readlink -nf $0)";)
 source "$script_dir/header.sh"
 validate_linux
 
-
 install_bin_path=$(tr -d "\n\r\t " < "/home/user/scripts/install_bin")
+file_hash=$(tr -d "\n\r\t " < "/home/user/hash")
 
-file_hash=($(md5sum "$install_bin_path"))
 set_vivado_version_from_hash "$file_hash"
 
-# Extract installer
-f_echo "Extracting installer"
-eval "$install_bin_path --target /home/user/installer --noexec"
+if [ "${install_bin_path##*.}" = "bin" ]; then
+    # Extract installer
+    f_echo "Extracting installer"
+    eval "$install_bin_path --target /home/user/installer --noexec"
 
-# Get AuthToken by repeating the following command until it succeeds
-f_echo "Log into your Xilinx account to download the necessary files."
-while ! /home/user/installer/xsetup -b AuthTokenGen
-do
-	f_echo "Your account information seems to be wrong. Please try logging in again."
-	sleep 1
-done
+    # Get AuthToken by repeating the following command until it succeeds
+    f_echo "Log into your Xilinx account to download the necessary files."
+    while ! /home/user/installer/xsetup -b AuthTokenGen
+    do
+        f_echo "Your account information seems to be wrong. Please try logging in again."
+        sleep 1
+    done
+elif [ "${install_bin_path##*.}" = "tar" ]; then
+    
+    # Get AuthToken by repeating the following command until it succeeds
+    cd /home/user/installer
+    while ! ./xsetup -b AuthTokenGen
+    do
+        f_echo "Your account information seems to be wrong. Please try logging in again."
+        sleep 1
+    done
+fi
 
 # Run installer
 f_echo "You successfully logged into your account. The installation will begin now."


### PR DESCRIPTION
Modified setup.sh and install_vivado.sh scripts to handle the SFD version of the installer (.tar file). Generates a local file with the calculated hash of the installer to save time on failed runs. Removed redundant hash calculation in install_vivado.sh as a consequence. cleanup.sh does not remove this file, must be manually removed.

Additionally added support for automatically changing Docker 4.35+ settings. Different named file (same location).