### PR TITLE
Add support for Vivado 2025.2 (202520)

### DIFF
--- a/scripts/configure_docker.sh
+++ b/scripts/configure_docker.sh
@@ -9,13 +9,16 @@ validate_macos
 function cannot_setup_docker {
     f_echo "Unfortunately, the script could not configure Docker automatically."
     f_echo "This means that you have to change the settings in the Docker Dashboard yourself:"
-    f_echo "Enable the Virtualization Framework, Rosetta emulation and set Swap to at least 2 GiB."
+    f_echo "Enable the Virtualization Framework, Rosetta emulation and set Swap to at least 8 GiB."
     f_echo "Restart Docker after applying the changes and then continue with the installation."
     wait_for_user_input
     exit 1
 }
 
-docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings.json"
+docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings-store.json"
+if ! [ -f "$docker_settings_file" ]; then
+    docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings.json"
+fi
 
 stop_docker
 
@@ -25,28 +28,26 @@ then
     cannot_setup_docker
 fi
 
-# check if the attributes to be modified exist
-if grep "\"useVirtualizationFramework\":" "$docker_settings_file" > /dev/null \
-&& grep "\"useVirtualizationFrameworkRosetta\":" "$docker_settings_file" > /dev/null \
-&& grep "\"swapMiB\":" "$docker_settings_file" > /dev/null
-then
-    :
+# set swap to minimum 8 GiB
+minSwap=8192
+if grep "\"SwapMiB\":" "$docker_settings_file" > /dev/null; then
+    # newer settings-store.json format
+    swapMiB=$(grep "\"SwapMiB\"" "$docker_settings_file" | sed "s/[^0-9]//g")
+    if [ "$swapMiB" -lt "$minSwap" ]; then
+        sed -i "" "s/\"SwapMiB\": [0-9]*/\"SwapMiB\": $minSwap/" "$docker_settings_file"
+    fi
+elif grep "\"swapMiB\":" "$docker_settings_file" > /dev/null \
+  && grep "\"useVirtualizationFramework\":" "$docker_settings_file" > /dev/null \
+  && grep "\"useVirtualizationFrameworkRosetta\":" "$docker_settings_file" > /dev/null; then
+    # legacy settings.json format
+    sed -i "" "s/\"useVirtualizationFramework\": false/\"useVirtualizationFramework\": true/" "$docker_settings_file"
+    sed -i "" "s/\"useVirtualizationFrameworkRosetta\": false/\"useVirtualizationFrameworkRosetta\": true/" "$docker_settings_file"
+    swapMiB=$(grep "\"swapMiB\"" "$docker_settings_file" | sed "s/[^0-9]//g")
+    if [ "$swapMiB" -lt "$minSwap" ]; then
+        sed -i "" "s/\"swapMiB\": [0-9]*/\"swapMiB\": $minSwap/" "$docker_settings_file"
+    fi
 else
     cannot_setup_docker
-fi
-
-# enable Virtualization Framework
-sed -i "" "s/\"useVirtualizationFramework\": false/\"useVirtualizationFramework\": true/" "$docker_settings_file"
-
-# enable Rosetta emulation
-sed -i "" "s/\"useVirtualizationFrameworkRosetta\": false/\"useVirtualizationFrameworkRosetta\": true/" "$docker_settings_file"
-
-# set swap to minimum 4 GiB
-minSwap=4096
-swapMiB=$(cat "$docker_settings_file" | grep "\"swapMiB\"" | sed "s/[^0-9]//g")
-if [ "$swapMiB" -lt "$minSwap" ]
-then
-    sed -i "" "s/\"swapMiB\": [0-9]*/\"swapMiB\": $minSwap/" "$docker_settings_file"
 fi
 
 f_echo "Configured Docker successfully"

--- a/scripts/hashes.sh
+++ b/scripts/hashes.sh
@@ -17,11 +17,6 @@ declare -A web_hashes=(
 )
 # hashes for the full installer
 # not tested yet
-declare -A sfd_hashes=()
-#declare -A sfd_hashes=(
-#    ["0bf810cf5eaa28a849ab52b9bfdd20a5"]=202210
-#    ["4b4e84306eb631fe67d3efb469122671"]=202220
-#    ["f2011ceba52b109e3551c1d3189a8c9c"]=202310
-#    ["64d64e9b937b6fd5e98b41811c74aab2"]=202320
-#    ["372c0b184e32001137424e395823de3c"]=202410
-#)
+declare -A sfd_hashes=(
+    ["abe838aa2e2d3d9b10fea94165e9a303"]=202520
+)

--- a/scripts/header.sh
+++ b/scripts/header.sh
@@ -34,7 +34,7 @@ function validate_linux {
 }
 
 function validate_internet {
-    if ! ping -q -c1 google.com &>/dev/null
+    if ! curl -s --connect-timeout 5 https://www.google.com &>/dev/null
     then
         f_echo "Internet connection required."
         exit 1

--- a/scripts/install_configs/202520.txt
+++ b/scripts/install_configs/202520.txt
@@ -1,0 +1,29 @@
+#### Vivado ML Standard Install Configuration ####
+Edition=Vivado ML Standard
+
+Product=Vivado
+
+# Path where AMD FPGAs & Adaptive SoCs software will be installed.
+Destination=/home/user/Xilinx
+
+# Choose the Products/Devices the you would like to install.
+Modules=Virtex UltraScale+ HBM FPGAs:1,Kintex UltraScale FPGAs:1,Artix UltraScale+ FPGAs:1,Spartan-7 FPGAs:1,Artix-7 FPGAs:1,Virtex UltraScale+ FPGAs:1,Vitis Model Composer(A toolbox for Simulink):0,DocNav:1,Zynq UltraScale+ MPSoCs:1,Zynq-7000 All Programmable SoC:1,Virtex UltraScale+ 58G FPGAs:1,Kintex-7 FPGAs:1,Install Devices for Kria SOMs and Starter Kits:1,Kintex UltraScale+ FPGAs:1
+
+# Choose the post install scripts you'd like to run as part of the finalization step. Please note that some of these scripts may require user interaction during runtime.
+InstallOptions=
+
+## Shortcuts and File associations ##
+# Choose whether Start menu/Application menu shortcuts will be created or not.
+CreateProgramGroupShortcuts=1
+
+# Choose the name of the Start menu/Application menu shortcut. This setting will be ignored if you choose NOT to create shortcuts.
+ProgramGroupFolder=Xilinx Design Tools
+
+# Choose whether shortcuts will be created for All users or just the Current user. Shortcuts can be created for all users only if you run the installer as administrator.
+CreateShortcutsForAllUsers=0
+
+# Choose whether shortcuts will be created on the desktop or not.
+CreateDesktopShortcuts=1
+
+# Choose whether file associations will be created or not.
+CreateFileAssociation=1

--- a/scripts/install_vivado.sh
+++ b/scripts/install_vivado.sh
@@ -24,6 +24,9 @@ do
 	sleep 1
 done
 
+# Limit Java heap to prevent OOM kills during download/install
+export JAVA_TOOL_OPTIONS="-Xmx2g"
+
 # Run installer
 f_echo "You successfully logged into your account. The installation will begin now."
 eula_args="XilinxEULA,3rdPartyEULA"


### PR DESCRIPTION
## Summary
- Add install config and hash for Vivado ML Standard 2025.2
- Fix `configure_docker.sh` to support newer `settings-store.json` format (Docker Desktop 4.x+) and raise minimum swap from 4 GiB to 8 GiB
- Add `JAVA_TOOL_OPTIONS=-Xmx2g` to prevent OOM kills during installation
- Fix `validate_internet` to use `curl` instead of `ping` (more reliable on macOS)

## Test Plan
- [ ] Run `setup.sh` with Vivado 2025.2 installer binary
- [ ] Verify Docker swap is set correctly on fresh Docker Desktop install

🤖 Generated with [Claude Code](https://claude.com/claude-code)