### PR TITLE
Add support for Vivado 2025.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vivado-on-silicon-mac
 This is a tool for installing [Vivado™](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools.html) on Arm®-based Apple Silicon Macs in a Rosetta-enabled virtual machine. It is in no way associated with Xilinx or AMD.
 
-*Updated for 2024!*
+*Updated for 2025!*
 
 The supported versions are:
 - 2021.1
@@ -9,6 +9,7 @@ The supported versions are:
 - 2023.1
 - 2023.2
 - 2024.1
+- 2025.2
 
 Due to unexpected behaviour in Rosetta emulation, most versions of macOS 14 (including 14.5) are not supported. macOS 13 may work, but the above versions were tested on macOS 15.
 

--- a/scripts/configure_docker.sh
+++ b/scripts/configure_docker.sh
@@ -9,44 +9,95 @@ validate_macos
 function cannot_setup_docker {
     f_echo "Unfortunately, the script could not configure Docker automatically."
     f_echo "This means that you have to change the settings in the Docker Dashboard yourself:"
-    f_echo "Enable the Virtualization Framework, Rosetta emulation and set Swap to at least 2 GiB."
+    f_echo "Enable the Virtualization Framework, Rosetta emulation and raise Swap as high as Docker Desktop allows."
     f_echo "Restart Docker after applying the changes and then continue with the installation."
     wait_for_user_input
     exit 1
 }
 
-docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings.json"
+docker_backend_sock="$HOME/Library/Containers/com.docker.docker/Data/backend.sock"
+docker_settings_file="$HOME/Library/Group Containers/group.com.docker/settings-store.json"
+preferredSwapMiB=8192
 
-stop_docker
+function get_flat_settings {
+    curl -s --unix-socket "$docker_backend_sock" http://localhost/app/settings/flat
+}
 
-# check if the settings file is in the expected place
-if ! [ -f "$docker_settings_file" ]
+if [ -S "$docker_backend_sock" ]
 then
-    cannot_setup_docker
+    flat_settings=$(get_flat_settings)
+    if [ -n "$flat_settings" ]
+    then
+        current_swap=$(printf '%s' "$flat_settings" | python3 -c 'import json,sys; print(json.load(sys.stdin)["swapMiB"])')
+        use_vf=$(printf '%s' "$flat_settings" | python3 -c 'import json,sys; print(str(json.load(sys.stdin)["useVirtualizationFramework"]).lower())')
+        use_rosetta=$(printf '%s' "$flat_settings" | python3 -c 'import json,sys; print(str(json.load(sys.stdin)["useVirtualizationFrameworkRosetta"]).lower())')
+
+        grouped_settings=$(curl -s --unix-socket "$docker_backend_sock" http://localhost/app/settings/grouped)
+        max_swap=$(printf '%s' "$grouped_settings" | python3 -c 'import json,sys; print(json.load(sys.stdin)["vm"]["resources"]["swapMiB"]["max"])')
+
+        target_swap=$preferredSwapMiB
+        if [ "$max_swap" -lt "$target_swap" ]
+        then
+            target_swap=$max_swap
+        fi
+
+        if [ "$target_swap" -lt 4096 ]
+        then
+            f_echo "Docker Desktop only allows $target_swap MiB of swap on this machine."
+        fi
+
+        if [ "$current_swap" -lt "$target_swap" ] || [ "$use_vf" != "true" ] || [ "$use_rosetta" != "true" ]
+        then
+            payload=$(python3 - <<PY
+import json
+print(json.dumps({
+    "desktop": {
+        "useVirtualizationFramework": True,
+        "useVirtualizationFrameworkRosetta": {"value": True},
+    },
+    "vm": {
+        "resources": {
+            "swapMiB": {"value": $target_swap},
+        }
+    }
+}))
+PY
+)
+
+            if ! curl -s -X POST --unix-socket "$docker_backend_sock" \
+                http://localhost/app/settings \
+                -H "Content-Type: application/json" \
+                -d "$payload" > /dev/null
+            then
+                cannot_setup_docker
+            fi
+
+            docker desktop restart > /dev/null
+        fi
+
+        f_echo "Configured Docker successfully"
+        exit 0
+    fi
 fi
 
-# check if the attributes to be modified exist
-if grep "\"useVirtualizationFramework\":" "$docker_settings_file" > /dev/null \
-&& grep "\"useVirtualizationFrameworkRosetta\":" "$docker_settings_file" > /dev/null \
-&& grep "\"swapMiB\":" "$docker_settings_file" > /dev/null
+if [ -f "$docker_settings_file" ]
 then
-    :
-else
-    cannot_setup_docker
+    current_swap=$(python3 -c 'import json, pathlib; p=pathlib.Path("'"$docker_settings_file"'"); data=json.loads(p.read_text()); print(data.get("SwapMiB", data.get("swapMiB", 0)))')
+    if [ "$current_swap" -lt 4096 ]
+    then
+        python3 - <<PY
+import json
+from pathlib import Path
+
+path = Path("$docker_settings_file")
+data = json.loads(path.read_text())
+data["SwapMiB"] = max(int(data.get("SwapMiB", data.get("swapMiB", 0))), 4096)
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+    fi
+
+    f_echo "Configured Docker successfully"
+    exit 0
 fi
 
-# enable Virtualization Framework
-sed -i "" "s/\"useVirtualizationFramework\": false/\"useVirtualizationFramework\": true/" "$docker_settings_file"
-
-# enable Rosetta emulation
-sed -i "" "s/\"useVirtualizationFrameworkRosetta\": false/\"useVirtualizationFrameworkRosetta\": true/" "$docker_settings_file"
-
-# set swap to minimum 4 GiB
-minSwap=4096
-swapMiB=$(cat "$docker_settings_file" | grep "\"swapMiB\"" | sed "s/[^0-9]//g")
-if [ "$swapMiB" -lt "$minSwap" ]
-then
-    sed -i "" "s/\"swapMiB\": [0-9]*/\"swapMiB\": $minSwap/" "$docker_settings_file"
-fi
-
-f_echo "Configured Docker successfully"
+cannot_setup_docker

--- a/scripts/de_start.sh
+++ b/scripts/de_start.sh
@@ -9,13 +9,15 @@ validate_linux
 
 export LD_PRELOAD="/lib/x86_64-linux-gnu/libudev.so.1 /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0"
 
+vivado_dir=$(find_vivado_dir)
+
 # if Vivado is installed
-if [ -d "/home/user/Xilinx" ]
+if [ -n "$vivado_dir" ]
 then
 	# Make Vivado connect to the xvcd server running on macOS
-	/home/user/Xilinx/Vivado/*/bin/hw_server -e "set auto-open-servers     xilinx-xvc:host.docker.internal:2542" &
-	/home/user/Xilinx/Vivado/*/settings64.sh
-	/home/user/Xilinx/Vivado/*/bin/vivado
+	source "$vivado_dir/settings64.sh"
+	"$vivado_dir/bin/hw_server" -e "set auto-open-servers     xilinx-xvc:host.docker.internal:2542" &
+	"$vivado_dir/bin/vivado"
 else
 	f_echo "The installation is incomplete."
 	wait_for_user_input

--- a/scripts/hashes.sh
+++ b/scripts/hashes.sh
@@ -17,11 +17,6 @@ declare -A web_hashes=(
 )
 # hashes for the full installer
 # not tested yet
-declare -A sfd_hashes=()
-#declare -A sfd_hashes=(
-#    ["0bf810cf5eaa28a849ab52b9bfdd20a5"]=202210
-#    ["4b4e84306eb631fe67d3efb469122671"]=202220
-#    ["f2011ceba52b109e3551c1d3189a8c9c"]=202310
-#    ["64d64e9b937b6fd5e98b41811c74aab2"]=202320
-#    ["372c0b184e32001137424e395823de3c"]=202410
-#)
+declare -A sfd_hashes=(
+    ["abe838aa2e2d3d9b10fea94165e9a303"]=202520
+)

--- a/scripts/header.sh
+++ b/scripts/header.sh
@@ -34,7 +34,7 @@ function validate_linux {
 }
 
 function validate_internet {
-    if ! ping -q -c1 google.com &>/dev/null
+    if ! curl -s --connect-timeout 5 https://www.google.com &>/dev/null
     then
         f_echo "Internet connection required."
         exit 1
@@ -86,6 +86,52 @@ function set_vivado_version_from_hash {
         exit 1
     fi
     return 0
+}
+
+function set_vivado_version_from_filename {
+    case "$(basename "$1")" in
+        *2021.1*)
+            vivado_version=202110
+            ;;
+        *2022.2*)
+            vivado_version=202220
+            ;;
+        *2023.1*)
+            vivado_version=202310
+            ;;
+        *2023.2*)
+            vivado_version=202320
+            ;;
+        *2024.1*)
+            vivado_version=202410
+            ;;
+        *2025.2*)
+            vivado_version=202520
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+function find_vivado_dir {
+    local candidate
+
+    for candidate in $(find /home/user/Xilinx \
+        -mindepth 2 -maxdepth 2 \
+        \( -path "/home/user/Xilinx/Vivado/*" -o -path "/home/user/Xilinx/*/Vivado" \) \
+        -type d 2>/dev/null | sort)
+    do
+        if [ -f "$candidate/settings64.sh" ] && [ -x "$candidate/bin/vivado" ]
+        then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
 }
 
 # The actual resolution is stored in the file vnc_resolution

--- a/scripts/install_configs/202520.txt
+++ b/scripts/install_configs/202520.txt
@@ -1,0 +1,29 @@
+#### Vivado ML Standard Install Configuration ####
+Edition=Vivado ML Standard
+
+Product=Vivado
+
+# Path where AMD FPGAs & Adaptive SoCs software will be installed.
+Destination=/home/user/Xilinx
+
+# Choose the Products/Devices the you would like to install.
+Modules=Virtex UltraScale+ HBM FPGAs:1,Kintex UltraScale FPGAs:1,Artix UltraScale+ FPGAs:1,Spartan-7 FPGAs:1,Artix-7 FPGAs:1,Virtex UltraScale+ FPGAs:1,Vitis Model Composer(A toolbox for Simulink):0,DocNav:1,Zynq UltraScale+ MPSoCs:1,Zynq-7000 All Programmable SoC:1,Virtex UltraScale+ 58G FPGAs:1,Kintex-7 FPGAs:1,Install Devices for Kria SOMs and Starter Kits:1,Kintex UltraScale+ FPGAs:1
+
+# Choose the post install scripts you'd like to run as part of the finalization step. Please note that some of these scripts may require user interaction during runtime.
+InstallOptions=
+
+## Shortcuts and File associations ##
+# Choose whether Start menu/Application menu shortcuts will be created or not.
+CreateProgramGroupShortcuts=1
+
+# Choose the name of the Start menu/Application menu shortcut. This setting will be ignored if you choose NOT to create shortcuts.
+ProgramGroupFolder=Xilinx Design Tools
+
+# Choose whether shortcuts will be created for All users or just the Current user. Shortcuts can be created for all users only if you run the installer as administrator.
+CreateShortcutsForAllUsers=0
+
+# Choose whether shortcuts will be created on the desktop or not.
+CreateDesktopShortcuts=1
+
+# Choose whether file associations will be created or not.
+CreateFileAssociation=1

--- a/scripts/install_vivado.sh
+++ b/scripts/install_vivado.sh
@@ -10,7 +10,14 @@ validate_linux
 install_bin_path=$(tr -d "\n\r\t " < "/home/user/scripts/install_bin")
 
 file_hash=($(md5sum "$install_bin_path"))
-set_vivado_version_from_hash "$file_hash"
+if ! set_vivado_version_from_hash "$file_hash"
+then
+	if ! set_vivado_version_from_filename "$install_bin_path"
+	then
+		f_echo "Unsupported installer file."
+		exit 1
+	fi
+fi
 
 # Extract installer
 f_echo "Extracting installer"
@@ -18,6 +25,7 @@ eval "$install_bin_path --target /home/user/installer --noexec"
 
 # Get AuthToken by repeating the following command until it succeeds
 f_echo "Log into your Xilinx account to download the necessary files."
+export JAVA_TOOL_OPTIONS="-Xmx2g"
 while ! /home/user/installer/xsetup -b AuthTokenGen
 do
 	f_echo "Your account information seems to be wrong. Please try logging in again."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,8 +77,7 @@ do
 	fi
 	# check file hash
 	file_hash=$(md5 -q "$installation_binary")
-	set_vivado_version_from_hash "$file_hash"
-	if [ "$?" -eq 0 ]
+	if set_vivado_version_from_hash "$file_hash" || set_vivado_version_from_filename "$installation_binary"
 	then
 		f_echo "Valid file provided. Detected version $vivado_version"
 		break
@@ -151,8 +150,17 @@ echo ""
 # copy de_start.desktop autostart file
 mkdir -p "$script_dir/../.config/autostart"
 cp "$script_dir/de_start.desktop" "$script_dir/../.config/autostart/de_start.desktop"
-mkdir "$script_dir/../Desktop"
+mkdir -p "$script_dir/../Desktop"
 
 # Start container
 f_echo "Now, the container is started (only terminal, no GUI) and the actual installation process begins."
+if docker ps --format '{{.Names}}' | grep -Fxq vivado_container
+then
+    f_echo "The Docker container 'vivado_container' is already running. Stop it first with: docker rm -f vivado_container"
+    exit 1
+fi
+if docker ps -a --format '{{.Names}}' | grep -Fxq vivado_container
+then
+    docker rm -f vivado_container > /dev/null 2>&1
+fi
 docker run --init -it --rm --name vivado_container --mount type=bind,source="$script_dir/..",target="/home/user" -p 127.0.0.1:5901:5901 --platform linux/amd64 x64-linux sudo -H -u user bash /home/user/scripts/install_vivado.sh


### PR DESCRIPTION
Follow-up to #81.

This adds support for the 2025.2 Linux self-extracting installer and handles the 2025 install layout change from `Xilinx/Vivado/<version>` to `Xilinx/<version>/Vivado`.

Changes:
- add 2025.2 installer hash and install config
- detect supported versions from installer filename as a fallback
- detect both old and new Vivado install layouts when launching
- make Docker Desktop configuration work with the current backend/settings format
- remove the stale `vivado_container` name conflict during setup
- update the README support list

Validation on Apple Silicon:
- host: macOS 26.4 on Apple M1 Pro
- installer: `FPGAs_AdaptiveSoCs_Unified_SDI_2025.2_1114_2157_Lin64.bin`
- install completed successfully
- `start_container.sh` launched the container and VNC desktop
- `de_start.sh` started `/home/user/Xilinx/2025.2/Vivado/bin/vivado` successfully
- `vivado -version` reported `vivado v2025.2 (64-bit)`
- batch synthesis completed successfully for a minimal Verilog design targeting `xc7a35tcpg236-1`

One notable difference from #81: on this machine Docker Desktop only exposed a `swapMiB.max` of 4096, so the script now raises swap to the highest value Docker Desktop allows instead of assuming 8192 MiB is always valid.

<img width="1988" height="1200" alt="Screenshot 2026-04-13 at 10 55 48 AM" src="https://github.com/user-attachments/assets/c04b0131-bfb9-46d0-a257-d114cf542a0c" />
